### PR TITLE
Update Dockerfile for building Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN \
 		libncurses5-dev \
 		libpci-dev \
 		libpixman-1-dev \
-		libsdl-dev \
+		libsdl2-dev \
 		libsystemd-dev \
 		libvncserver-dev \
 		libx11-dev \
@@ -54,9 +54,7 @@ RUN \
 		pandoc \
 		patch \
 		pkg-config \
-		python \
-		python \
-		python-dev \
+		python3 \
 		python3-dev \
 		texinfo \
 		texlive-fonts-extra \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN \
 	apt-get -qqy install \
 		autoconf \
 		autopoint \
+		bc \
 		bcc \
 		bin86 \
 		bison \
@@ -36,11 +37,13 @@ RUN \
 		libc6-dev-i386 \
 		libcurl4 \
 		libcurl4-openssl-dev \
+		libelf-dev \
 		liblzma-dev \
 		libncurses5-dev \
 		libpci-dev \
 		libpixman-1-dev \
 		libsdl2-dev \
+		libssl-dev \
 		libsystemd-dev \
 		libvncserver-dev \
 		libx11-dev \


### PR DESCRIPTION
Container targets `debian:stable` which is a newer release now.  I picked `libsdl2-dev` at random, maybe should also install `libsdl1.2-dev`.  I really don't know what needs this package (and many others).